### PR TITLE
Add security CI/CD pipeline for GitHub Actions in addition to existing security measures

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,19 +24,13 @@ jobs:
 
   sast:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
+    container:
+      image: semgrep/semgrep
     steps:
       - uses: actions/checkout@v6
 
       - name: Semgrep SAST
-        uses: semgrep/semgrep-action@v1
-        with:
-          config: >-
-            p/python
-            p/bandit
-            p/secrets
+        run: semgrep scan --config p/python --config p/bandit --config p/secrets .
 
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Gitleaks secret detection
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: TruffleHog secret detection
+        uses: trufflesecurity/trufflehog@v3
+        with:
+          extra_args: --only-verified
 
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Semgrep SAST
-        run: semgrep scan --config p/python --config p/bandit --config p/secrets .
+        run: semgrep scan --error --config p/python --config p/bandit --config p/secrets .
 
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,6 +22,22 @@ jobs:
         with:
           extra_args: --only-verified
 
+  sast:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Semgrep SAST
+        uses: semgrep/semgrep-action@v1
+        with:
+          config: >-
+            p/python
+            p/bandit
+            p/secrets
+
   dependency-review:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
@@ -35,19 +51,3 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
-
-  sast:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: python
-
-      - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,9 +18,9 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog secret detection
-        uses: trufflesecurity/trufflehog@v3
+        uses: trufflesecurity/trufflehog@main
         with:
-          extra_args: --only-verified
+          extra_args: --results=verified,unknown
 
   sast:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,53 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  secret-detection:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks secret detection
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dependency-review:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
+  sast:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3

--- a/src/vowl/contracts/check_reference_generated.py
+++ b/src/vowl/contracts/check_reference_generated.py
@@ -583,7 +583,8 @@ class LogicalTypeOptionsCheckReference(GeneratedColumnCheckReference):
                 if pattern is None:
                     # Fall through to JDK format pattern (validated in __init__)
                     pattern = _jdk_format_to_regex(val)
-                    assert pattern is not None  # guaranteed by _validate_format
+                    if pattern is None:
+                        raise RuntimeError(f"_jdk_format_to_regex returned None for '{val}' — _validate_format should have rejected this")
                 cast_col = exp.TryCast(
                     this=col, to=exp.DataType.build("VARCHAR"), safe=True
                 )
@@ -596,7 +597,8 @@ class LogicalTypeOptionsCheckReference(GeneratedColumnCheckReference):
 
             # date / timestamp / time — already validated in _validate_format
             pattern = _jdk_format_to_regex(val)
-            assert pattern is not None  # guaranteed by _validate_format
+            if pattern is None:
+                raise RuntimeError(f"_jdk_format_to_regex returned None for '{val}' — _validate_format should have rejected this")
             cast_col = exp.TryCast(
                 this=col, to=exp.DataType.build("VARCHAR"), safe=True
             )

--- a/src/vowl/contracts/models/generate_models.py
+++ b/src/vowl/contracts/models/generate_models.py
@@ -21,7 +21,7 @@ import re
 
 # Bandit B404: This is a trusted, repository-maintained developer utility script
 # that intentionally invokes a local codegen CLI; subprocess is required here.
-import subprocess  # nosec B404
+import subprocess  # nosec B404 # nosemgrep: gitlab.bandit.B404
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
### Summary

- Add a new security.yml GitHub Actions workflow replicating GitLab CI security scanning (secret detection, dependency scanning, SAST)
- Improve error handling in LogicalTypeOptionsCheckReference by replacing assert statements with explicit RuntimeError for clearer debugging in production

### Changes
Security workflow (.github/workflows/security.yml):

- Secret detection — TruffleHog scans commit history for leaked credentials (verified + unknown results). No license required.
- SAST — Semgrep with p/python, p/bandit, and p/secrets rulesets. Fails the job on findings (--error). No token required.
- Dependency review — Blocks PRs that introduce high-severity vulnerable dependencies (fail-on-severity: high)
All three jobs are configured to fail on findings.

Runs on pushes to main and on pull requests.

Error handling fix (src/vowl/contracts/check_reference_generated.py):

- Replace bare assert pattern is not None with RuntimeError that includes the failing value, so issues are surfaced in production rather than silently passing when Python optimizations are enabled (-O).