### PR TITLE
Chore/add security.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev install-lean-ci-test install-all generate-models doxygen doxygen-open doxygen-clean clean test lint lint-fix format format-check typecheck check verify security-scan security-scan-json security-audit release-check release-upload-testpypi release-tag docs-serve docs-build docs-clean
+.PHONY: help install install-dev install-lean-ci-test install-all generate-models doxygen doxygen-open doxygen-clean clean test lint lint-fix format format-check typecheck check verify security-scan security-audit release-check release-upload-testpypi release-tag docs-serve docs-build docs-clean
 
 UV ?= uv
 
@@ -22,8 +22,7 @@ help:
 	@echo "  clean            Remove build artifacts and cache files"
 	@echo "  test             Run tests"
 	@echo "  verify           Run all checks and tests"
-	@echo "  security-scan    Run Bandit security scan"
-	@echo "  security-scan-json Run Bandit security scan and write JSON report"
+	@echo "  security-scan    Run Semgrep SAST scan (matches CI)"
 	@echo "  security-audit   Run dependency vulnerability audit (pip-audit)"
 	@echo "  release-check    Build package artifacts and run Twine validation"
 	@echo "  release-upload-testpypi Upload dist artifacts to TestPyPI"
@@ -131,11 +130,7 @@ check: format-check lint typecheck
 
 # Security scanning
 security-scan:
-	$(UV) run bandit -r src/vowl
-
-security-scan-json:
-	mkdir -p reports
-	$(UV) run bandit -r src/vowl -f json -o reports/bandit.json
+	uvx semgrep scan --error --config p/python --config p/bandit --config p/secrets .
 
 security-audit:
 	$(UV) export --frozen --format requirements-txt --all-extras --group dev --no-hashes --no-annotate --no-header | grep -v '^-e \.$$' > /tmp/vowl-requirements-audit.txt

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help:
 	@echo "  clean            Remove build artifacts and cache files"
 	@echo "  test             Run tests"
 	@echo "  verify           Run all checks and tests"
-	@echo "  security-scan    Run Semgrep SAST scan (matches CI)"
+	@echo "  security-scan    Run Semgrep SAST scan"
 	@echo "  security-audit   Run dependency vulnerability audit (pip-audit)"
 	@echo "  release-check    Build package artifacts and run Twine validation"
 	@echo "  release-upload-testpypi Upload dist artifacts to TestPyPI"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in `vowl`, please report it through [GitHub Security Advisories](https://github.com/govtech-data-practice/Vowl/security/advisories/new).
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+When reporting, please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- The potential impact
+- Any suggested fixes (if applicable)
+
+## Security Measures
+
+Automated security checks run in CI on every push and pull request. See [`.github/workflows/security.yml`](.github/workflows/security.yml) for details.
+
+Contributors can run security checks locally via `make security-scan` and `make security-audit`.
+
+## Disclaimer
+
+Please note that while GovTech conducts SAST scans prior to publishing the software or updates for “vowl” and may provide security updates on a “best efforts basis” from time to time, “vowl” is licensed under the MIT license, including the disclaimer relating to the software. Without prejudice and in addition to the terms of the license for “vowl”:
+
+(a) use of the software is entirely at your own risk, and you shall not rely on the SAST scans (or any scans), security updates, or the fact that GovTech had published the software; and
+
+(b) GovTech disclaims all warranties and representations of any kind, whether express or implied, and all liability of whatever nature, arising out of or in connection with the scans and security updates, including without limitation any warranty or representation that the software or updates are free from errors, malicious code, or security issues.
+
+GovTech may, at its sole and absolute discretion, discontinue the scans and/or security updates at any time without giving any notice.


### PR DESCRIPTION
Summary

- Add SECURITY.md with vulnerability reporting instructions (via GitHub Security Advisories), a pointer to the CI security workflow, and GovTech's security disclaimer
- Update make security-scan to use Semgrep (matching the CI pipeline) instead of Bandit, and remove the unused security-scan-json target