### PR TITLE
Update CHANGELOG for v0.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Nil
 
+## [0.0.3] - 2026-06-29
+
+### ✨ Annotated table output
+
+This release introduces **annotated table output**: failed-row results can now be merged back into a single consolidated, annotated view of your source data, making it far easier to see *which* rows failed and *why* in context.
+
+### Added
+- **Annotated table output**: merge per-check failed rows into a consolidated, annotated copy of the source table. See the [Annotated Output](https://github.com/govtech-data-practice/vowl/blob/main/README.md#annotated-output) section in the README and the [usage patterns notebook](https://github.com/govtech-data-practice/vowl/blob/main/examples/vowl_usage_patterns_demo.ipynb) for usage (#35).
+- **Pooled adapter** for concurrent query execution. The pooled adapter maintains a connection pool so multiple checks can run in parallel against a backend, with new tests covering concurrency and multi-source parallel execution (#32).
+- Unique, primaryKey, and duplicateValues checks are now mergeable into the annotated output. Previously these auto-generated checks landed in `residues`; they now emit full participating rows that fold into the consolidated table (#36).
+- **Preset-driven `check_info` column** on annotated output: a JSON array of objects (one per failing check) selectable via `names` (default), `summary`, or `full` presets, exposing each check's `dimension`, `tags`, and `target` per row. Set it on `ValidationConfig.annotated_check_info` or per call (`get_annotated_output(check_info=...)` / `save(check_info=...)`). Residues are now emitted one entry per non-mergeable check, carrying the same `check_info` column (#37).
+- Security CI/CD pipeline for GitHub Actions, complementing existing security measures (#29).
+- `SECURITY.md` security policy (#30).
+
+### Changed
+- Auto-generated unique, primaryKey, and duplicateValues checks now count *participating rows* (rather than duplicate groups), so `actual_value` / `failed_rows_count` match the annotated row count. The PASS/FAIL verdict is unchanged. The percent-unit `duplicateValues` variant remains non-mergeable as its result is a ratio (#36).
+
+### Fixed
+- Percent-unit library checks (`unit: "percent"`, e.g. `nullValues`, `missingValues`, `invalidValues`, `duplicateValues`) generated invalid SQL (aliased scalar subqueries) and came back as `ERROR` instead of a real pass/fail verdict. They now render valid SQL and return a correct ratio-based verdict, guarded by SQL re-parse and end-to-end DuckDB tests (#37).
+
+### Dependencies
+- Bumped `cryptography` (#34).
+- Bumped `tornado` from 6.5.6 to 6.5.7 (#33) and from 6.5.5 to 6.5.6 (#31).
+- Bumped `urllib3` from 2.6.3 to 2.7.0 (#27).
+- Bumped the `uv` dependency group with 2 updates (#28).
+
 ## [0.0.2] - 2026-04-27
 
 ### 🎉 vowl is now an official ODCS vendor!
@@ -67,6 +93,7 @@ Initial public release of **vowl**.
 - `THIRD_PARTY_NOTICES` and `LICENSE_AUDIT_REPORT.md`.
 - `CONTRIBUTING.md` with development setup and release workflow.
 
-[Unreleased]: https://github.com/govtech-data-practice/vowl/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/govtech-data-practice/vowl/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/govtech-data-practice/vowl/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/govtech-data-practice/vowl/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/govtech-data-practice/vowl/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -1071,13 +1071,13 @@ result.display_full_report()
 | ✅ **Multi-Connection Checks**     | Cross-table referential checks between different servers/databases via `MultiSourceAdapter`                                                                             |
 | ✅ **Optional Extras**             | Add optional Spark support with `.[spark]` or install `.[all]`                                                                                                          |
 | ✅ **Custom Adapters & Executors** | Extensible architecture - create custom adapters and executors by extending `BaseAdapter`, `BaseExecutor`, or `SQLExecutor`                                             |
+| ✅ **Parallel Check Execution**    | Run checks in parallel for faster validation across large contracts via the pooled adapter                                                                             |
 
 ### Planned
 
 | Capability                       | Description                                                                  | Status  |
 | -------------------------------- | ---------------------------------------------------------------------------- | ------- |
 | 🔬 **Alternative Check Engines** | Support for dqx, dbt, Soda, Great Expectations (subject to licensing review) | Planned |
-| 📅 **Parallel Check Execution**  | Run checks in parallel for faster validation across large contracts          | Planned |
 | 📅 **CLI Interface**             | Command-line interface for running validations directly from the terminal    | Planned |
 | 📅 **vowl-ui**                   | Web-based validation interface for vowl                                      | Planned |
 

--- a/README.md
+++ b/README.md
@@ -1071,7 +1071,7 @@ result.display_full_report()
 | ✅ **Multi-Connection Checks**     | Cross-table referential checks between different servers/databases via `MultiSourceAdapter`                                                                             |
 | ✅ **Optional Extras**             | Add optional Spark support with `.[spark]` or install `.[all]`                                                                                                          |
 | ✅ **Custom Adapters & Executors** | Extensible architecture - create custom adapters and executors by extending `BaseAdapter`, `BaseExecutor`, or `SQLExecutor`                                             |
-| ✅ **Parallel Check Execution**    | Run checks in parallel for faster validation across large contracts via the pooled adapter                                                                             |
+| ✅ **Parallel Check Execution**    | Run checks in parallel for faster validation across large contracts via the pooled adapter                                                                              |
 
 ### Planned
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,7 +21,7 @@ description: >-
 | **Multi-Connection Checks**     | Cross-table referential checks between different servers/databases via `MultiSourceAdapter`                                                                             |
 | **Optional Extras**             | Add optional Spark support with `.[spark]` or install `.[all]`                                                                                                          |
 | **Custom Adapters & Executors** | Extensible architecture. Create custom adapters and executors by extending `BaseAdapter`, `BaseExecutor`, or `SQLExecutor`                                              |
-| **Parallel Check Execution**    | Run checks in parallel for faster validation across large contracts via the pooled adapter                                                                             |
+| **Parallel Check Execution**    | Run checks in parallel for faster validation across large contracts via the pooled adapter                                                                              |
 
 ## Planned
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,12 +21,12 @@ description: >-
 | **Multi-Connection Checks**     | Cross-table referential checks between different servers/databases via `MultiSourceAdapter`                                                                             |
 | **Optional Extras**             | Add optional Spark support with `.[spark]` or install `.[all]`                                                                                                          |
 | **Custom Adapters & Executors** | Extensible architecture. Create custom adapters and executors by extending `BaseAdapter`, `BaseExecutor`, or `SQLExecutor`                                              |
+| **Parallel Check Execution**    | Run checks in parallel for faster validation across large contracts via the pooled adapter                                                                             |
 
 ## Planned
 
 | Capability                    | Description                                                                  | Status  |
 | ----------------------------- | ---------------------------------------------------------------------------- | ------- |
 | **Alternative Check Engines** | Support for dqx, dbt, Soda, Great Expectations (subject to licensing review) | Planned |
-| **Parallel Check Execution**  | Run checks in parallel for faster validation across large contracts          | Planned |
 | **CLI Interface**             | Command-line interface for running validations directly from the terminal    | Planned |
 | **vowl-ui**                   | Web-based validation interface for vowl                                      | Planned |


### PR DESCRIPTION
Updates `CHANGELOG.md` with the `[0.0.3]` section ahead of the v0.0.3 release.

Covers all PRs merged since v0.0.2 (#27–#37):

- **Annotated table output** (#35) and its preset-driven `check_info` column (#37)
- **Pooled adapter** for concurrent query execution (#32)
- `unique` / `primaryKey` / `duplicateValues` checks now mergeable into annotated output (#36)
- Security CI/CD pipeline (#29) and `SECURITY.md` (#30)
- Fix: percent-unit library checks now return a real verdict instead of `ERROR` (#37)
- Dependency bumps (#27, #28, #31, #33, #34)