### PR TITLE
Add workflow_dispatch trigger to Documentation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Adds a `workflow_dispatch:` trigger to `.github/workflows/docs.yml` so the Documentation deploy can be re-run manually from the Actions UI (one click) instead of requiring a fresh commit to `main`.

## Why

Since 2026-07-06 the docs deploy has been failing at the `actions/deploy-pages@v5` step with a server-side `Deployment failed, try again later.` (empty error description). The build and artifact upload both succeed — the failure is inside GitHub's Pages provisioning backend (`GET /pages` returns `status: null`, `GET /pages/builds/latest` returns 404).

Recovering from that state involves toggling the Pages source in **Settings → Pages** to re-provision the site, then redeploying. Without `workflow_dispatch`, "redeploy" means pushing a throwaway commit each time. This trigger makes re-running a single click.

Not a fix for the backend failure itself — that requires the Settings-UI re-provision (and possibly a GitHub Support ticket) — just removes the friction of retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)