### PR TITLE
fix: remediate verified security scanner findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Run ruff lint
         run: uvx ruff check src/ tests/
@@ -46,7 +46,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install dependencies
         run: uv sync --group lean-ci-test
@@ -73,7 +73,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install dependencies
         run: uv sync
@@ -88,7 +88,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   release:
     needs: publish
@@ -106,7 +106,7 @@ jobs:
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,14 +18,14 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog secret detection
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@363923b901c911a9164f50b6c423f47c15372b1c # v3.97.4
         with:
           extra_args: --results=verified,unknown --exclude-paths=.trufflehog-exclude.txt
 
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep:1.176.1@sha256:34ab619bf1391a24bfda3f05debd0d8a6ce3093c2d5f9d39cfc00f83c1397823
     steps:
       - uses: actions/checkout@v6
 

--- a/src/vowl/contracts/check_reference_generated.py
+++ b/src/vowl/contracts/check_reference_generated.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
@@ -406,6 +407,14 @@ class LogicalTypeOptionsCheckReference(GeneratedColumnCheckReference):
         "format",
     }
 
+    # Options whose value is emitted into generated SQL as a bare numeric
+    # literal via ``exp.Literal.number``. sqlglot renders that value verbatim
+    # (unquoted), so a non-numeric value would be injected into the query. The
+    # value is coerced to a real number at construction time to prevent SQL
+    # injection through ``logicalTypeOptions``.
+    _NON_NEGATIVE_INT_OPTIONS = frozenset({"minLength", "maxLength"})
+    _NUMERIC_OPTIONS = frozenset({"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"})
+
     def __init__(self, contract: Contract, property_path: str, option_key: str, option_value: Any):
         if option_key not in self.SUPPORTED_OPTIONS:
             warnings.warn(
@@ -418,10 +427,63 @@ class LogicalTypeOptionsCheckReference(GeneratedColumnCheckReference):
 
         super().__init__(contract, property_path, f"logicalTypeOptions.{option_key}")
         self._option_key = option_key
-        self._option_value = option_value
+        # Coerce numeric-bound options to real numbers so they cannot inject
+        # arbitrary SQL when rendered as literals in _build_ast().
+        if option_key in self._NON_NEGATIVE_INT_OPTIONS:
+            self._option_value = self._coerce_non_negative_int(option_key, option_value)
+        elif option_key in self._NUMERIC_OPTIONS:
+            self._option_value = self._coerce_number(option_key, option_value)
+        else:
+            self._option_value = option_value
 
         if option_key == "format":
             self._validate_format()
+
+    @staticmethod
+    def _coerce_number(option_key: str, value: Any) -> int | float:
+        """Return *value* as an int/float, rejecting anything non-numeric.
+
+        Accepts JSON numbers directly and strictly-numeric strings; rejects
+        booleans, NaN/inf, and any value that is not a clean number (which is
+        how SQL-injection payloads would arrive). Raises ``ValueError`` — caught
+        by the caller in ``contract.py`` and downgraded to an unsupported check.
+        """
+        # bool is an int subclass but is never a valid numeric bound.
+        if isinstance(value, bool):
+            raise ValueError(f"logicalTypeOptions '{option_key}' must be numeric, got boolean: {value!r}")
+
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            if math.isnan(value) or math.isinf(value):
+                raise ValueError(f"logicalTypeOptions '{option_key}' must be finite, got: {value!r}")
+            return value
+        if isinstance(value, str):
+            text = value.strip()
+            try:
+                num: int | float = int(text)
+            except ValueError:
+                try:
+                    num = float(text)
+                except ValueError:
+                    raise ValueError(f"logicalTypeOptions '{option_key}' must be numeric, got: {value!r}") from None
+            if isinstance(num, float) and (math.isnan(num) or math.isinf(num)):
+                raise ValueError(f"logicalTypeOptions '{option_key}' must be finite, got: {value!r}")
+            return num
+
+        raise ValueError(f"logicalTypeOptions '{option_key}' must be numeric, got: {value!r}")
+
+    @classmethod
+    def _coerce_non_negative_int(cls, option_key: str, value: Any) -> int:
+        """Return *value* as a non-negative int, rejecting anything else."""
+        num = cls._coerce_number(option_key, value)
+        if isinstance(num, float):
+            if not num.is_integer():
+                raise ValueError(f"logicalTypeOptions '{option_key}' must be an integer, got: {value!r}")
+            num = int(num)
+        if num < 0:
+            raise ValueError(f"logicalTypeOptions '{option_key}' must be non-negative, got: {value!r}")
+        return num
 
     def _validate_format(self) -> None:
         """Check that this logical_type + format combo is actionable.

--- a/src/vowl/contracts/contract.py
+++ b/src/vowl/contracts/contract.py
@@ -1,8 +1,10 @@
+import ipaddress
 import os
 import re
+import socket
 import warnings
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import yaml
 from jsonpath_ng import parse as jsonpath_parse
@@ -12,6 +14,72 @@ from .models.ODCS_types import DataContract, Server
 
 if TYPE_CHECKING:
     from .check_reference import CheckReference
+
+
+# Maximum number of HTTP redirects to follow when fetching a remote contract.
+_MAX_HTTP_REDIRECTS = 5
+
+
+class ContractURLError(ValueError):
+    """Raised when a contract URL is disallowed (e.g. points at an internal host)."""
+
+
+def _is_disallowed_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True for IPs that must not be fetched (SSRF protection).
+
+    Blocks loopback, private (RFC1918 / ULA), link-local (incl. the cloud
+    metadata address 169.254.169.254), reserved, multicast and unspecified
+    addresses. IPv4-mapped IPv6 addresses are unwrapped and re-checked.
+    """
+    if getattr(ip, "ipv4_mapped", None) is not None:
+        ip = ip.ipv4_mapped  # type: ignore[assignment]
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+
+
+def _validate_public_http_url(url: str) -> None:
+    """Validate that *url* is an http(s) URL that resolves to a public host.
+
+    This is an SSRF guard for the unauthenticated contract-loading entry point:
+    it blocks non-http(s) schemes and any host that resolves to an internal,
+    loopback, link-local (cloud metadata) or otherwise reserved IP address.
+
+    Note: DNS is resolved here and again by the HTTP client, so a determined
+    attacker controlling DNS could still rebind between the two lookups. This
+    check stops the common cases (literal internal IPs/hostnames, metadata
+    endpoints, redirects to internal hosts) without a custom transport.
+
+    Raises:
+        ContractURLError: If the scheme or resolved address is not allowed.
+    """
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        raise ContractURLError(f"Unsupported URL scheme '{parsed.scheme}' for contract fetch: {url}")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ContractURLError(f"Contract URL has no host: {url}")
+
+    port = parsed.port or (443 if scheme == "https" else 80)
+
+    try:
+        addrinfos = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise ContractURLError(f"Could not resolve contract host '{hostname}': {e}") from e
+
+    if not addrinfos:
+        raise ContractURLError(f"Could not resolve contract host '{hostname}'")
+
+    for *_, sockaddr in addrinfos:
+        try:
+            ip = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            raise ContractURLError(f"Unexpected address for contract host '{hostname}': {sockaddr[0]}") from None
+        if _is_disallowed_ip(ip):
+            raise ContractURLError(
+                f"Refusing to fetch contract from non-public address {ip} (host '{hostname}'). "
+                "Only public HTTP(S) endpoints are allowed."
+            )
 
 
 class Contract:
@@ -76,10 +144,26 @@ class Contract:
         elif (hostname == "gitlab.com" or hostname.endswith(".gitlab.com")) and "/-/blob/" in parsed.path:
             raw_url = url.replace("/-/blob/", "/-/raw/")
 
+        # SSRF protection: validate the target (and every redirect hop) resolves
+        # to a public address before we send a request to it. Redirects are
+        # followed manually so an attacker-controlled 3xx cannot bounce us to an
+        # internal host or the cloud metadata endpoint.
         try:
-            response = requests.get(raw_url, timeout=30)
-            response.raise_for_status()
-            return response.text
+            current_url = raw_url
+            for _ in range(_MAX_HTTP_REDIRECTS + 1):
+                _validate_public_http_url(current_url)
+                response = requests.get(current_url, timeout=30, allow_redirects=False)
+                if response.is_redirect or response.is_permanent_redirect:
+                    location = response.headers.get("Location")
+                    if not location:
+                        break
+                    current_url = urljoin(current_url, location)
+                    continue
+                response.raise_for_status()
+                return response.text
+            raise OSError(f"Too many redirects fetching contract from URL {url}")
+        except ContractURLError:
+            raise
         except requests.RequestException as e:
             raise OSError(f"Error fetching contract from URL {url}: {e}") from e
 

--- a/src/vowl/executors/security.py
+++ b/src/vowl/executors/security.py
@@ -52,8 +52,76 @@ FORBIDDEN_STATEMENT_TYPES = frozenset(
         # Permission management
         exp.Grant,
         exp.Revoke,
+        # File / external-database access and bulk load-unload.
+        # COPY can read from or write to local files; ATTACH/DETACH can mount
+        # arbitrary database files or remote endpoints (e.g. DuckDB ATTACH).
+        exp.Copy,
+        exp.Attach,
+        exp.Detach,
         # Other dangerous operations
-        exp.Command,  # Generic commands like TRUNCATE, etc.
+        exp.Command,  # Generic commands like TRUNCATE, INSTALL, LOAD, etc.
+    }
+)
+
+# SQL functions that can read local files or make outbound network requests.
+# Even inside a plain SELECT these bypass the read-only sandbox: DuckDB table
+# functions such as read_csv()/read_parquet() accept local paths *and* http(s)
+# URLs (arbitrary file disclosure + SSRF), and several backends expose scalar
+# file-read / remote-query helpers. Names are compared case-insensitively.
+DANGEROUS_SQL_FUNCTIONS = frozenset(
+    {
+        # DuckDB file / table functions (local file read + SSRF via httpfs)
+        "read_csv",
+        "read_csv_auto",
+        "read_parquet",
+        "parquet_scan",
+        "parquet_metadata",
+        "parquet_schema",
+        "parquet_file_metadata",
+        "parquet_kv_metadata",
+        "read_json",
+        "read_json_auto",
+        "read_json_objects",
+        "read_json_objects_auto",
+        "read_ndjson",
+        "read_ndjson_auto",
+        "read_ndjson_objects",
+        "read_text",
+        "read_blob",
+        "read_xlsx",
+        "sniff_csv",
+        "glob",
+        "delta_scan",
+        "iceberg_scan",
+        "iceberg_metadata",
+        "iceberg_snapshots",
+        # DuckDB scanners into other databases
+        "postgres_scan",
+        "postgres_query",
+        "mysql_scan",
+        "mysql_query",
+        "sqlite_scan",
+        "sqlite_query",
+        # Spatial extension file readers
+        "st_read",
+        "st_readosm",
+        "st_drivers",
+        # PostgreSQL file / remote access helpers
+        "pg_read_file",
+        "pg_read_binary_file",
+        "pg_ls_dir",
+        "pg_stat_file",
+        "lo_import",
+        "lo_export",
+        "dblink",
+        "dblink_exec",
+        # SQLite file-io / extension helpers
+        "readfile",
+        "writefile",
+        "load_extension",
+        "fsdir",
+        # MySQL / generic file read (also covered by regex patterns)
+        "load_file",
     }
 )
 
@@ -156,6 +224,10 @@ def validate_read_only_query(query: str, dialect: str = "postgres") -> None:
         # Additional check: ensure no subqueries contain write operations
         _check_for_write_subqueries(stmt, query)
 
+        # Block file-read / network table functions (e.g. DuckDB read_csv,
+        # read_parquet) that bypass the read-only sandbox even within a SELECT.
+        _check_for_dangerous_functions(stmt, query)
+
 
 def _check_for_select_side_effects(ast: exp.Expression, original_query: str) -> None:
     """Reject SELECT forms that still mutate state, such as SELECT INTO."""
@@ -186,6 +258,53 @@ def _check_for_write_subqueries(ast: exp.Expression, original_query: str) -> Non
             raise SQLSecurityError(
                 f"Write operation '{stmt_name}' found in subquery or CTE. Only read operations are allowed.",
                 violation_type="write_in_subquery",
+                query=original_query,
+            )
+
+
+def _function_name(node: exp.Expression) -> str | None:
+    """Return the lower-cased SQL function name for a function node, if any.
+
+    Handles both ``exp.Anonymous`` (functions sqlglot has no dedicated class
+    for, e.g. ``read_text``) and typed function classes (e.g. ``exp.ReadCSV``
+    whose ``sql_name()`` is ``READ_CSV``).
+    """
+    if isinstance(node, exp.Anonymous):
+        name = node.name
+        return name.lower() if name else None
+    if isinstance(node, exp.Func):
+        try:
+            return node.sql_name().lower()
+        except Exception:
+            return None
+    return None
+
+
+def _check_for_dangerous_functions(ast: exp.Expression, original_query: str) -> None:
+    """
+    Reject queries that call file-read or network table/scalar functions.
+
+    These functions (e.g. DuckDB ``read_csv``/``read_parquet``/``read_text``,
+    PostgreSQL ``pg_read_file``, SQLite ``readfile``) are valid inside a plain
+    SELECT but let an attacker read arbitrary local files or reach internal
+    network endpoints, defeating the read-only SQL sandbox.
+
+    Args:
+        ast: The parsed SQL AST to check.
+        original_query: The original query string for error reporting.
+
+    Raises:
+        SQLSecurityError: If a denied function is found anywhere in the query.
+    """
+    for node in ast.walk():
+        if not isinstance(node, exp.Func):
+            continue
+        name = _function_name(node)
+        if name and name in DANGEROUS_SQL_FUNCTIONS:
+            raise SQLSecurityError(
+                f"Function '{name}' is not allowed: it can read local files or make "
+                "network requests, which bypasses the read-only SQL sandbox.",
+                violation_type="file_or_network_function",
                 query=original_query,
             )
 

--- a/src/vowl/validation/result.py
+++ b/src/vowl/validation/result.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import warnings
 from collections.abc import Iterable, Sequence
 from dataclasses import asdict
@@ -58,6 +59,30 @@ _METADATA_COLUMNS = (
     "check_info_item",
     "tables_in_query",
 )
+
+# Characters allowed in a generated output filename component. Everything else
+# (path separators, "..", NUL, etc.) is collapsed to "_" so that table/schema
+# names taken from a contract cannot escape the output directory.
+_FILENAME_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _safe_filename_component(value: str, *, fallback: str = "output") -> str:
+    """Sanitize a string for use as a single output-filename component.
+
+    Replaces path separators and other unsafe characters with underscores,
+    neutralizes ``..`` parent-directory references, collapses runs of
+    underscores, and strips leading/trailing separators. The result cannot
+    traverse directories (``..``, ``/etc/...``) or be interpreted as an
+    option. Empty or all-separator inputs collapse to *fallback*.
+    """
+    cleaned = _FILENAME_SAFE_RE.sub("_", str(value))
+    # Neutralize any remaining parent-directory references.
+    cleaned = cleaned.replace("..", "_")
+    # Collapse repeated underscores and trim leading/trailing separators.
+    cleaned = re.sub(r"_+", "_", cleaned).strip("._-")
+    if not cleaned:
+        return fallback
+    return cleaned
 
 
 class ValidationResult:
@@ -1165,6 +1190,9 @@ class ValidationResult:
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
 
+        # Sanitize the caller-supplied prefix so it cannot traverse directories.
+        prefix = _safe_filename_component(prefix, fallback="vowl_results")
+
         check_csv = output_path / f"{prefix}_check_results.csv"
         _pa_csv.write_csv(
             self.get_check_results_df(
@@ -1178,7 +1206,7 @@ class ValidationResult:
 
         if mode in ("failed_rows", "both"):
             for table_key, df in self._get_consolidated_output_dfs().items():
-                safe_key = table_key.replace(", ", "_").replace(" ", "_")
+                safe_key = _safe_filename_component(table_key.replace(", ", "_").replace(" ", "_"))
                 csv_path = output_path / f"{prefix}_{safe_key}.csv"
                 _pa_csv.write_csv(df.to_arrow(), str(csv_path))
                 saved_files.append(str(csv_path))
@@ -1186,7 +1214,7 @@ class ValidationResult:
         if mode in ("annotated", "both"):
             out = self.get_annotated_output(check_info=check_info)
             for schema, df in out["annotated"].items():
-                safe_key = schema.replace(", ", "_").replace(" ", "_")
+                safe_key = _safe_filename_component(schema.replace(", ", "_").replace(" ", "_"))
                 csv_path = output_path / f"{prefix}_{safe_key}_annotated.csv"
                 _pa_csv.write_csv(df.to_arrow(), str(csv_path))
                 saved_files.append(str(csv_path))
@@ -1197,7 +1225,9 @@ class ValidationResult:
             # the same rows twice in a different (per-check) shape.
             if mode == "annotated":
                 for residue_key, df in out["residues"].items():
-                    safe_key = residue_key.replace("::", "_").replace(", ", "_").replace(" ", "_")
+                    safe_key = _safe_filename_component(
+                        residue_key.replace("::", "_").replace(", ", "_").replace(" ", "_")
+                    )
                     csv_path = output_path / f"{prefix}_{safe_key}_residue.csv"
                     _pa_csv.write_csv(df.to_arrow(), str(csv_path))
                     saved_files.append(str(csv_path))

--- a/tests/test_check_reference_unit_coverage.py
+++ b/tests/test_check_reference_unit_coverage.py
@@ -315,6 +315,44 @@ def test_logical_type_options_reference_builds_queries_for_supported_options(
     assert "COUNT(*)" in check["query"]
 
 
+@pytest.mark.parametrize(
+    ("option_key", "malicious_value"),
+    [
+        ("minimum", "0) UNION SELECT password FROM secrets --"),
+        ("maximum", "1; DROP TABLE users"),
+        ("exclusiveMinimum", "0 OR 1=1"),
+        ("exclusiveMaximum", "abc"),
+        ("multipleOf", "2)) OR true --"),
+        ("minLength", "-1) UNION SELECT 1 --"),
+        ("maxLength", "5 OR 1=1"),
+    ],
+)
+def test_logical_type_options_reference_rejects_non_numeric_bounds(
+    monkeypatch: pytest.MonkeyPatch,
+    option_key: str,
+    malicious_value: str,
+):
+    """Numeric-bound options must reject non-numeric values (SQL injection guard)."""
+    contract = _make_contract(monkeypatch)
+    property_index = 1 if option_key in {"minLength", "maxLength"} else 0
+    with pytest.raises(ValueError, match="must be (numeric|an integer|non-negative|finite)"):
+        LogicalTypeOptionsCheckReference(
+            contract,
+            f"$.schema[0].properties[{property_index}]",
+            option_key,
+            malicious_value,
+        )
+
+
+def test_logical_type_options_reference_accepts_numeric_strings(monkeypatch: pytest.MonkeyPatch):
+    """Clean numeric strings are coerced and rendered as literals, not injected."""
+    contract = _make_contract(monkeypatch)
+    ref = LogicalTypeOptionsCheckReference(contract, "$.schema[0].properties[0]", "minimum", "5")
+    query = ref.get_check()["query"]
+    assert "5" in query
+    assert "UNION" not in query.upper()
+
+
 def test_logical_type_options_reference_raises_for_missing_query_implementation(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/test_contract_unit_coverage.py
+++ b/tests/test_contract_unit_coverage.py
@@ -60,8 +60,18 @@ def postgres_server(server: str, environment: str) -> dict:
 
 
 class FakeResponse:
-    def __init__(self, text: str) -> None:
+    def __init__(
+        self,
+        text: str,
+        *,
+        is_redirect: bool = False,
+        is_permanent_redirect: bool = False,
+        headers: dict | None = None,
+    ) -> None:
         self.text = text
+        self.is_redirect = is_redirect
+        self.is_permanent_redirect = is_permanent_redirect
+        self.headers = headers or {}
 
     def raise_for_status(self) -> None:
         return None
@@ -128,14 +138,21 @@ def test_contract_load_wraps_file_read_errors(tmp_path: Path, monkeypatch: pytes
         Contract.load(str(path))
 
 
+def _allow_all_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass the SSRF host-resolution guard for tests that run offline and
+    only exercise URL rewriting / error wrapping."""
+    monkeypatch.setattr("vowl.contracts.contract._validate_public_http_url", lambda url: None)
+
+
 def test_contract_fetches_github_blob_urls_via_raw_url(monkeypatch: pytest.MonkeyPatch):
     called_urls: list[str] = []
     payload = yaml.safe_dump(minimal_contract_data())
 
-    def fake_get(url: str, timeout: int):
+    def fake_get(url: str, timeout: int, **kwargs):
         called_urls.append(url)
         return FakeResponse(payload)
 
+    _allow_all_urls(monkeypatch)
     monkeypatch.setattr("requests.get", fake_get)
 
     contract = Contract.load("https://github.com/org/repo/blob/main/contract.yaml")
@@ -148,10 +165,11 @@ def test_contract_fetches_gitlab_blob_urls_via_raw_url(monkeypatch: pytest.Monke
     called_urls: list[str] = []
     payload = yaml.safe_dump(minimal_contract_data())
 
-    def fake_get(url: str, timeout: int):
+    def fake_get(url: str, timeout: int, **kwargs):
         called_urls.append(url)
         return FakeResponse(payload)
 
+    _allow_all_urls(monkeypatch)
     monkeypatch.setattr("requests.get", fake_get)
 
     contract = Contract.load("https://gitlab.com/org/repo/-/blob/main/contract.yaml")
@@ -164,10 +182,11 @@ def test_contract_fetches_plain_http_urls_without_rewriting(monkeypatch: pytest.
     called_urls: list[str] = []
     payload = yaml.safe_dump(minimal_contract_data())
 
-    def fake_get(url: str, timeout: int):
+    def fake_get(url: str, timeout: int, **kwargs):
         called_urls.append(url)
         return FakeResponse(payload)
 
+    _allow_all_urls(monkeypatch)
     monkeypatch.setattr("requests.get", fake_get)
 
     contract = Contract.load("https://example.com/contracts/users.yaml")
@@ -177,9 +196,10 @@ def test_contract_fetches_plain_http_urls_without_rewriting(monkeypatch: pytest.
 
 
 def test_contract_http_fetch_failures_are_wrapped_as_io_errors(monkeypatch: pytest.MonkeyPatch):
-    def fake_get(url: str, timeout: int):
+    def fake_get(url: str, timeout: int, **kwargs):
         raise requests.RequestException("network down")
 
+    _allow_all_urls(monkeypatch)
     monkeypatch.setattr("requests.get", fake_get)
 
     with pytest.raises(OSError, match="Error fetching contract from URL https://example.com/contracts/users.yaml"):
@@ -200,6 +220,109 @@ def test_contract_http_fetch_raises_import_error_when_requests_is_unavailable(
 
     with pytest.raises(ImportError, match="requests' package is required"):
         Contract._fetch_from_http_url("https://example.com/contracts/users.yaml")
+
+
+def _stub_getaddrinfo(monkeypatch: pytest.MonkeyPatch, ip: str) -> None:
+    """Force DNS resolution of any host to *ip* for SSRF-guard tests."""
+    import socket as _socket
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(_socket.AF_INET, _socket.SOCK_STREAM, _socket.IPPROTO_TCP, "", (ip, port or 0))]
+
+    monkeypatch.setattr("vowl.contracts.contract.socket.getaddrinfo", fake_getaddrinfo)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata (link-local)
+        "http://127.0.0.1/contract.yaml",  # loopback
+        "http://10.0.0.5/contract.yaml",  # RFC1918 private
+        "http://192.168.1.1/contract.yaml",  # RFC1918 private
+    ],
+)
+def test_contract_http_fetch_blocks_internal_addresses(url: str):
+    from vowl.contracts.contract import ContractURLError
+
+    def fail_get(*args, **kwargs):
+        raise AssertionError("requests.get must not be called for a blocked URL")
+
+    # No DNS stub needed: these are IP literals. requests.get must never fire.
+    import vowl.contracts.contract as contract_mod
+
+    original = getattr(contract_mod, "requests", None)
+    try:
+        with pytest.raises(ContractURLError, match="non-public address"):
+            Contract._fetch_from_http_url(url)
+    finally:
+        if original is not None:
+            contract_mod.requests = original
+
+
+def test_contract_http_fetch_blocks_non_http_scheme():
+    from vowl.contracts.contract import ContractURLError
+
+    with pytest.raises(ContractURLError, match="Unsupported URL scheme"):
+        Contract._fetch_from_http_url("file:///etc/passwd")
+
+
+def test_contract_http_fetch_blocks_hostname_resolving_to_private_ip(monkeypatch: pytest.MonkeyPatch):
+    from vowl.contracts.contract import ContractURLError
+
+    # A public-looking hostname that (per our stub) resolves to a private IP.
+    _stub_getaddrinfo(monkeypatch, "10.1.2.3")
+
+    def fail_get(*args, **kwargs):
+        raise AssertionError("requests.get must not be called for a blocked URL")
+
+    monkeypatch.setattr("requests.get", fail_get)
+
+    with pytest.raises(ContractURLError, match="non-public address"):
+        Contract._fetch_from_http_url("https://internal.example.com/contract.yaml")
+
+
+def test_contract_http_fetch_blocks_redirect_to_internal_host(monkeypatch: pytest.MonkeyPatch):
+    from vowl.contracts.contract import ContractURLError
+
+    payload = yaml.safe_dump(minimal_contract_data())
+    resolved: list[str] = []
+
+    def fake_validate(url: str) -> None:
+        # Public for the first (external) hop, private for the redirect target.
+        resolved.append(url)
+        if "internal" in url:
+            raise ContractURLError("Refusing to fetch contract from non-public address 10.0.0.9")
+
+    def fake_get(url: str, timeout: int, **kwargs):
+        # First call returns a redirect to an internal host.
+        if "internal" not in url:
+            return FakeResponse(
+                "",
+                is_redirect=True,
+                headers={"Location": "https://internal.example.com/secret.yaml"},
+            )
+        return FakeResponse(payload)
+
+    monkeypatch.setattr("vowl.contracts.contract._validate_public_http_url", fake_validate)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    with pytest.raises(ContractURLError, match="non-public address"):
+        Contract._fetch_from_http_url("https://example.com/contract.yaml")
+
+    assert "https://internal.example.com/secret.yaml" in resolved
+
+
+def test_contract_http_fetch_allows_public_host(monkeypatch: pytest.MonkeyPatch):
+    payload = yaml.safe_dump(minimal_contract_data())
+    _stub_getaddrinfo(monkeypatch, "93.184.216.34")  # public IP
+
+    def fake_get(url: str, timeout: int, **kwargs):
+        return FakeResponse(payload)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    contract = Contract.load("https://example.com/contracts/users.yaml")
+    assert contract.get_schema_names() == ["users"]
 
 
 def test_contract_fetches_from_s3(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_result_rendering_unit_coverage.py
+++ b/tests/test_result_rendering_unit_coverage.py
@@ -1,7 +1,34 @@
 from __future__ import annotations
 
+import pytest
+
+from vowl.validation.result import _safe_filename_component
 from vowl.validation.result_models import SingleTableSummary
 from vowl.validation.result_rendering import format_unique_passed_rows
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("public.users", "public.users"),
+        ("orders_2024", "orders_2024"),
+        ("../../etc/passwd", "etc_passwd"),
+        ("../../../root/.ssh/authorized_keys", "root_.ssh_authorized_keys"),
+        ("/absolute/path", "absolute_path"),
+        ("schema/table", "schema_table"),
+        ("..", "output"),
+        ("", "output"),
+        ("nul\x00byte", "nul_byte"),
+        ("a b, c", "a_b_c"),
+    ],
+)
+def test_safe_filename_component_strips_traversal(value: str, expected: str):
+    result = _safe_filename_component(value)
+    assert result == expected
+    # Result must never contain path separators or parent-dir references.
+    assert "/" not in result
+    assert "\\" not in result
+    assert not result.startswith(".")
 
 
 def _summary(*, total_rows, passed_row_percentage, passed_unique_rows=0):

--- a/tests/test_sql_security.py
+++ b/tests/test_sql_security.py
@@ -283,6 +283,62 @@ class TestValidateQuerySecurity:
         validate_query_security(query)  # Should not raise
 
 
+class TestDangerousFunctions:
+    """Tests for the file-read / network table-function guard."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "SELECT * FROM read_csv('/etc/passwd')",
+            "SELECT * FROM read_csv_auto('/etc/passwd')",
+            "SELECT * FROM read_parquet('http://169.254.169.254/latest/meta-data/')",
+            "SELECT read_text('/etc/passwd')",
+            "SELECT read_blob('/etc/shadow')",
+            "SELECT * FROM read_json_auto('/tmp/x.json')",
+            "SELECT * FROM glob('/etc/*')",
+            "SELECT count(*) FROM users WHERE id IN (SELECT * FROM read_csv('/etc/passwd'))",
+        ],
+    )
+    def test_duckdb_file_functions_blocked(self, query):
+        """DuckDB file/network table functions inside a SELECT must be rejected."""
+        with pytest.raises(SQLSecurityError) as exc_info:
+            validate_read_only_query(query, dialect="duckdb")
+        assert exc_info.value.violation_type == "file_or_network_function"
+
+    def test_pg_read_file_blocked(self):
+        """PostgreSQL file-read helper must be rejected."""
+        with pytest.raises(SQLSecurityError) as exc_info:
+            validate_read_only_query("SELECT pg_read_file('/etc/passwd')", dialect="postgres")
+        assert exc_info.value.violation_type == "file_or_network_function"
+
+    def test_sqlite_readfile_blocked(self):
+        """SQLite readfile() must be rejected."""
+        with pytest.raises(SQLSecurityError) as exc_info:
+            validate_read_only_query("SELECT readfile('/etc/passwd')", dialect="sqlite")
+        assert exc_info.value.violation_type == "file_or_network_function"
+
+    def test_copy_statement_blocked(self):
+        """COPY (file read/write) must be rejected."""
+        with pytest.raises(SQLSecurityError):
+            validate_read_only_query("COPY users FROM '/etc/passwd'", dialect="duckdb")
+
+    def test_attach_statement_blocked(self):
+        """ATTACH (mounting external db/file) must be rejected."""
+        with pytest.raises(SQLSecurityError):
+            validate_read_only_query("ATTACH 'evil.db' AS evil", dialect="duckdb")
+
+    def test_normal_functions_allowed(self):
+        """Ordinary scalar/aggregate functions must still pass."""
+        validate_read_only_query(
+            "SELECT COUNT(*), UPPER(name), LENGTH(email) FROM users GROUP BY name, email",
+            dialect="duckdb",
+        )
+
+    def test_column_named_like_reader_allowed(self):
+        """A column merely named similarly is not a function call and is allowed."""
+        validate_read_only_query("SELECT read_count FROM stats", dialect="duckdb")
+
+
 class TestSanitizeIdentifier:
     """Tests for identifier sanitization."""
 


### PR DESCRIPTION
## Summary

Remediates 7 verified findings from the security scan. Full non-docker test suite passes (719 passed); `ruff format`/`ruff check` clean.

| # | Finding | Fix |
|---|---------|-----|
| asgard-0003 | SSRF in contract HTTP(S) fetch | Validate URLs resolve to public hosts (block private/loopback/link-local/reserved/metadata IPs), enforce http(s) scheme, follow redirects manually (max 5) re-validating each hop |
| asgard-0001 | SQL sandbox bypass via DuckDB file/network table functions | Name-based denylist (`read_csv`, `read_parquet`, `pg_read_file`, `readfile`, …) enforced in `validate_read_only_query` |
| asgard-0004 | SQL sandbox bypass via `COPY`/`ATTACH`/`DETACH` | Added to forbidden statement types |
| asgard-0005 | SQL injection via unquoted numeric bounds | Coerce `minimum`/`maximum`/`exclusive*`/`multipleOf` to validated numbers and `minLength`/`maxLength` to non-negative ints at construction; non-numeric downgraded to unsupported check |
| asgard-0006 | Path traversal in result output filenames | Sanitize filename components (strip separators, collapse `..`) |
| asgard-0002 | Unpinned GitHub Actions | Pin `setup-uv`, `gh-action-pypi-publish`, `action-gh-release` to commit SHAs |
| asgard-0007 | Unpinned Actions / container image | Pin `trufflehog` to SHA; pin `semgrep` image to sha256 digest |

## Tests

Added coverage for each fix across `tests/test_contract_unit_coverage.py`, `tests/test_sql_security.py`, `tests/test_check_reference_unit_coverage.py`, and `tests/test_result_rendering_unit_coverage.py` (SSRF blocking, dangerous-function/statement blocking, numeric-bound injection rejection, filename traversal stripping).

## Behavior note

The SSRF fix (asgard-0003) blocks loading contracts from **internal/private HTTP(S) URLs** (e.g. an internal Git/artifact host on a private IP, or `localhost`). `s3://` URIs (boto3) and local file paths are unaffected. Public GitHub/GitLab raw URLs continue to work. If internal contract hosting is needed, an opt-in host allowlist can be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)