### PR TITLE
docs: complete README and SECURITY governance sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,17 @@ vowl (vee-owl 🦉) is a validation engine for [Open Data Contract Standard (ODC
 
 🏆 **Official ODCS Vendor**: `vowl` is actively maintained and listed on the official [ODCS vendors list](https://github.com/bitol-io/open-data-contract-standard/blob/main/vendors.md) as a natively compatible tool.
 
+## Who it's for
+
+- Government agencies adopting ODCS for data governance
+- Data engineers and platform teams needing declarative data quality validation, in both public and private sectors
+- The international open-source data quality community, including ODCS ecosystem participants
+
 ## Table of Contents
 
 **Part 1 · Getting Started**
 
+- [Who it's for](#who-its-for)
 - [Features](#features)
 - [Installation](#installation)
 - [Validate in 3 lines](#validate-in-3-lines)
@@ -43,7 +50,10 @@ vowl (vee-owl 🦉) is a validation engine for [Open Data Contract Standard (ODC
 **More**
 
 - [Roadmap](#roadmap)
+- [Status](#status)
 - [Contributing](#contributing)
+- [Owner](#owner)
+- [Security](#security)
 - [License](#license)
 
 ---
@@ -1084,9 +1094,27 @@ result.display_full_report()
 
 ---
 
+## Status
+
+**Active** — under ongoing development; issues and PRs are monitored.
+
+---
+
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to get started.
+
+---
+
+## Owner
+
+Maintained by the **Data Engineering Practice, GTO** ([`govtech-data-practice`](https://github.com/govtech-data-practice)).
+
+---
+
+## Security
+
+See [`SECURITY.md`](SECURITY.md) for how to report a vulnerability and which versions are supported.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in `vowl`, please report it through [GitHub Security Advisories](https://github.com/govtech-data-practice/Vowl/security/advisories/new).
+If you discover a security vulnerability in `vowl`, please report it through [GitHub Security Advisories](https://github.com/govtech-data-practice/vowl/security/advisories/new).
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
@@ -12,6 +12,16 @@ When reporting, please include:
 - Steps to reproduce the issue
 - The potential impact
 - Any suggested fixes (if applicable)
+
+## What to Expect
+
+- **Acknowledgement:** we aim to acknowledge your report within 3 working days.
+- **Updates:** we will keep you informed as we investigate and work on a fix.
+- **Disclosure:** we follow coordinated disclosure and will agree timing with you before any public disclosure.
+
+## Supported Versions
+
+Only the latest released version of `vowl` on [PyPI](https://pypi.org/project/vowl/) receives security updates. Please upgrade to the latest release before reporting an issue.
 
 ## Security Measures
 


### PR DESCRIPTION
Completes the repository's documentation with the standard governance sections expected of a published GovTech open-source project.

## Changes

**README.md** — adds the missing standard sections:
- `Who it's for` (intended audience)
- `Status` (lifecycle: **Active**)
- `Owner` (Maintained by the govtech-data-practice team)
- `Security` (links `SECURITY.md`)
- Table of Contents updated with anchors for each

**SECURITY.md** — completes the disclosure policy:
- `What to Expect` (3-working-day acknowledgement + coordinated disclosure)
- `Supported Versions`
- Fixes an incorrect capitalised repo path (`.../Vowl/...` → `.../vowl/...`) in the advisory URL

Documentation only — no functional/code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)