### PR TITLE
fix: close SQL replacement-scan and DNS-rebinding SSRF gaps

### DIFF
--- a/src/vowl/contracts/contract.py
+++ b/src/vowl/contracts/contract.py
@@ -138,7 +138,11 @@ def _validate_public_http_url(url: str) -> tuple[str, str]:
             validated_ip = sockaddr[0]
 
     # Every resolved address passed the check above; pin to the first one.
-    assert validated_ip is not None  # noqa: S101 - guaranteed by the non-empty, all-validated loop
+    # (validated_ip is always set here because addrinfos is non-empty and every
+    # entry was validated, but we raise explicitly rather than assert so the
+    # invariant is enforced in optimized (-O) runs too.)
+    if validated_ip is None:  # pragma: no cover - defensive, unreachable
+        raise ContractURLError(f"Could not resolve contract host '{hostname}'")
     return hostname, validated_ip
 
 

--- a/src/vowl/contracts/contract.py
+++ b/src/vowl/contracts/contract.py
@@ -1,8 +1,10 @@
+import contextvars
 import ipaddress
 import os
 import re
 import socket
 import warnings
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse
 
@@ -36,17 +38,68 @@ def _is_disallowed_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool
     return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
 
 
-def _validate_public_http_url(url: str) -> None:
+# Pins the IP address that the HTTP client is allowed to connect to for the
+# current fetch, keyed by hostname. Set by ``_pinned_dns`` around each request so
+# the outbound connection uses the exact address we validated, closing the
+# DNS-rebinding TOCTOU between validation and connection. Uses a ContextVar so it
+# is isolated per thread / async task and needs no global lock.
+_pinned_dns_target: contextvars.ContextVar[tuple[str, str] | None] = contextvars.ContextVar(
+    "_vowl_pinned_dns_target", default=None
+)
+_dns_pin_installed = False
+
+
+def _install_dns_pin() -> None:
+    """Install a one-time urllib3 hook that honours ``_pinned_dns_target``.
+
+    urllib3 (used by requests) resolves the hostname again at connect time. We
+    wrap its ``create_connection`` so that, whenever a pin is active for the host
+    being dialled, the socket connects to the pre-validated IP instead of a
+    freshly re-resolved (and possibly rebound) address. TLS SNI and certificate
+    verification are unaffected because the request URL still carries the
+    hostname. All other hosts pass through untouched.
+    """
+    global _dns_pin_installed
+    if _dns_pin_installed:
+        return
+    import urllib3.util.connection as _u3_connection
+
+    _original_create_connection = _u3_connection.create_connection
+
+    def _pinned_create_connection(address, *args, **kwargs):  # type: ignore[no-untyped-def]
+        pin = _pinned_dns_target.get()
+        if pin is not None:
+            host, port = address
+            if host == pin[0]:
+                address = (pin[1], port)
+        return _original_create_connection(address, *args, **kwargs)
+
+    _u3_connection.create_connection = _pinned_create_connection
+    _dns_pin_installed = True
+
+
+@contextmanager
+def _pinned_dns(hostname: str, ip: str):
+    """Pin *hostname* to *ip* for HTTP connections made within the block."""
+    _install_dns_pin()
+    token = _pinned_dns_target.set((hostname, ip))
+    try:
+        yield
+    finally:
+        _pinned_dns_target.reset(token)
+
+
+def _validate_public_http_url(url: str) -> tuple[str, str]:
     """Validate that *url* is an http(s) URL that resolves to a public host.
 
-    This is an SSRF guard for the unauthenticated contract-loading entry point:
-    it blocks non-http(s) schemes and any host that resolves to an internal,
-    loopback, link-local (cloud metadata) or otherwise reserved IP address.
+    This is an SSRF guard for the contract-loading entry point: it blocks
+    non-http(s) schemes and any host that resolves to an internal, loopback,
+    link-local (cloud metadata) or otherwise reserved IP address.
 
-    Note: DNS is resolved here and again by the HTTP client, so a determined
-    attacker controlling DNS could still rebind between the two lookups. This
-    check stops the common cases (literal internal IPs/hostnames, metadata
-    endpoints, redirects to internal hosts) without a custom transport.
+    Returns the ``(hostname, ip)`` of a validated public address so the caller
+    can pin the outbound connection to it (see ``_pinned_dns``), preventing a
+    DNS-rebinding attacker from swapping in an internal address between this
+    check and the actual request.
 
     Raises:
         ContractURLError: If the scheme or resolved address is not allowed.
@@ -70,6 +123,7 @@ def _validate_public_http_url(url: str) -> None:
     if not addrinfos:
         raise ContractURLError(f"Could not resolve contract host '{hostname}'")
 
+    validated_ip: str | None = None
     for *_, sockaddr in addrinfos:
         try:
             ip = ipaddress.ip_address(sockaddr[0])
@@ -80,6 +134,12 @@ def _validate_public_http_url(url: str) -> None:
                 f"Refusing to fetch contract from non-public address {ip} (host '{hostname}'). "
                 "Only public HTTP(S) endpoints are allowed."
             )
+        if validated_ip is None:
+            validated_ip = sockaddr[0]
+
+    # Every resolved address passed the check above; pin to the first one.
+    assert validated_ip is not None  # noqa: S101 - guaranteed by the non-empty, all-validated loop
+    return hostname, validated_ip
 
 
 class Contract:
@@ -145,14 +205,17 @@ class Contract:
             raw_url = url.replace("/-/blob/", "/-/raw/")
 
         # SSRF protection: validate the target (and every redirect hop) resolves
-        # to a public address before we send a request to it. Redirects are
+        # to a public address before we send a request to it, then pin the
+        # connection to that validated IP so a DNS-rebinding attacker cannot swap
+        # in an internal address between the check and the request. Redirects are
         # followed manually so an attacker-controlled 3xx cannot bounce us to an
         # internal host or the cloud metadata endpoint.
         try:
             current_url = raw_url
             for _ in range(_MAX_HTTP_REDIRECTS + 1):
-                _validate_public_http_url(current_url)
-                response = requests.get(current_url, timeout=30, allow_redirects=False)
+                pin_host, pin_ip = _validate_public_http_url(current_url)
+                with _pinned_dns(pin_host, pin_ip):
+                    response = requests.get(current_url, timeout=30, allow_redirects=False)
                 if response.is_redirect or response.is_permanent_redirect:
                     location = response.headers.get("Location")
                     if not location:

--- a/src/vowl/executors/multi_source_sql_executor.py
+++ b/src/vowl/executors/multi_source_sql_executor.py
@@ -28,10 +28,16 @@ class MultiSourceSQLExecutor(SQLExecutor):
     """
     SQL Executor for handling cross-schema queries in multi-source scenarios.
 
-    This executor handles queries that reference multiple tables/schemas:
-    - For DuckDB-compatible backends (postgres, mysql, sqlite), uses ATTACH
-      to connect directly without copying data
-    - For other backends, materializes required data into a local DuckDB instance
+    This executor handles queries that reference multiple tables/schemas via
+    two modes (see ``run_single_check``):
+    - Mode 1 (compatible adapters): when every referenced table is served by
+      the same backend *and the same connection* (``BaseAdapter.is_compatible_with``),
+      the check is delegated to that adapter's own SQL executor and runs
+      natively there — no data is copied.
+    - Mode 2 (incompatible adapters, e.g. tables spread across different
+      connections or backends): each required table is materialized into a
+      fresh local DuckDB instance via ``export_table_as_arrow`` and the query
+      runs against those copies.
 
     Filter conditions from each adapter are applied to their respective tables
     using the same subquery pattern as IbisSQLExecutor.
@@ -186,9 +192,12 @@ class MultiSourceSQLExecutor(SQLExecutor):
         local_con,
     ) -> None:
         """
-        Attach a database or materialize a table into local DuckDB.
+        Make a source table available in local DuckDB.
 
-        Prefers ATTACH for supported backends, falls back to materialization.
+        Currently this always materializes the table (pulls its rows via the
+        source adapter's ``export_table_as_arrow`` and registers the resulting
+        Arrow table in local DuckDB). DuckDB ATTACH is not yet implemented — see
+        the TODO below.
 
         Args:
             adapter: The source adapter.
@@ -198,8 +207,10 @@ class MultiSourceSQLExecutor(SQLExecutor):
         if schema_name in self._attached_sources:
             return
 
-        # TODO: Use DuckDB ATTACH for supported backends (postgres, mysql, sqlite)
-        # instead of materializing, to avoid copying data.
+        # TODO: For DuckDB-compatible backends (postgres, mysql, sqlite), use
+        # DuckDB ATTACH to stream directly from the source instead of
+        # materializing, to avoid copying data. Until then we always
+        # materialize regardless of backend.
         self._materialize_table_to_duckdb(adapter, schema_name, local_con)
         self._attached_sources.add(schema_name)
 

--- a/src/vowl/executors/security.py
+++ b/src/vowl/executors/security.py
@@ -125,6 +125,36 @@ DANGEROUS_SQL_FUNCTIONS = frozenset(
     }
 )
 
+# File extensions DuckDB will read via a "replacement scan" when a bare string
+# is used as a table source (e.g. ``FROM 'data.parquet'``). Used to catch the
+# relative-filename form that contains no path separator or URL scheme.
+_REPLACEMENT_SCAN_EXTENSIONS = frozenset(
+    {
+        "parquet",
+        "csv",
+        "tsv",
+        "txt",
+        "json",
+        "jsonl",
+        "ndjson",
+        "arrow",
+        "ipc",
+        "feather",
+        "orc",
+        "avro",
+        "xlsx",
+        "xls",
+        "gz",
+        "zst",
+        "bz2",
+        "zip",
+        "db",
+        "sqlite",
+        "duckdb",
+        "delta",
+    }
+)
+
 # Statement type names for the allowlist approach (more restrictive)
 ALLOWED_STATEMENT_TYPES = frozenset(
     {
@@ -228,6 +258,11 @@ def validate_read_only_query(query: str, dialect: str = "postgres") -> None:
         # read_parquet) that bypass the read-only sandbox even within a SELECT.
         _check_for_dangerous_functions(stmt, query)
 
+        # Block bare file paths / URLs used as a table source, which DuckDB
+        # reads via a "replacement scan" (SELECT * FROM 'http://...'), bypassing
+        # the function denylist above since there is no function call.
+        _check_for_replacement_scan_tables(stmt, query)
+
 
 def _check_for_select_side_effects(ast: exp.Expression, original_query: str) -> None:
     """Reject SELECT forms that still mutate state, such as SELECT INTO."""
@@ -307,6 +342,52 @@ def _check_for_dangerous_functions(ast: exp.Expression, original_query: str) -> 
                 violation_type="file_or_network_function",
                 query=original_query,
             )
+
+
+def _looks_like_replacement_scan_source(name: str | None) -> bool:
+    """Return True if *name* looks like a file path or URL rather than an identifier.
+
+    DuckDB performs a "replacement scan" when a bare string is used as a table
+    source: ``SELECT * FROM 'http://host/x'`` fetches a URL and
+    ``SELECT * FROM '/etc/passwd.csv'`` reads a local file. sqlglot parses these
+    as an ``exp.Table`` wrapping a (quoted) ``exp.Identifier`` whose name is the
+    path/URL, so they slip past the function denylist. Legitimate schema/table
+    identifiers never contain path separators, a URL scheme, or a data-file
+    extension, so those markers distinguish an attack from a real identifier.
+    """
+    if not name:
+        return False
+    # Path separators (POSIX / Windows / UNC) and any URL scheme (``http:``,
+    # ``s3:``, ``file:``, a Windows drive letter, …).
+    if "/" in name or "\\" in name or ":" in name:
+        return True
+    # Bare relative data file with no separator, e.g. ``secret.parquet``.
+    _, dot, ext = name.rpartition(".")
+    return bool(dot) and ext.lower() in _REPLACEMENT_SCAN_EXTENSIONS
+
+
+def _check_for_replacement_scan_tables(ast: exp.Expression, original_query: str) -> None:
+    """Reject table sources that are file paths or URLs (DuckDB replacement scan).
+
+    Args:
+        ast: The parsed SQL AST to check.
+        original_query: The original query string for error reporting.
+
+    Raises:
+        SQLSecurityError: If any FROM/JOIN target looks like a path or URL.
+    """
+    for table in ast.find_all(exp.Table):
+        for ident in table.find_all(exp.Identifier):
+            name = ident.this if isinstance(ident.this, str) else ident.name
+            if _looks_like_replacement_scan_source(name):
+                raise SQLSecurityError(
+                    f"Table source '{name}' looks like a file path or URL. DuckDB would "
+                    "read it via a replacement scan, which can disclose local files or "
+                    "reach internal network endpoints, bypassing the read-only SQL sandbox. "
+                    "Only plain schema/table identifiers are allowed.",
+                    violation_type="replacement_scan_table",
+                    query=original_query,
+                )
 
 
 def detect_sql_injection(query: str) -> tuple[str, str] | None:

--- a/tests/test_contract_unit_coverage.py
+++ b/tests/test_contract_unit_coverage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pandas as pd
 import pytest
@@ -140,8 +141,12 @@ def test_contract_load_wraps_file_read_errors(tmp_path: Path, monkeypatch: pytes
 
 def _allow_all_urls(monkeypatch: pytest.MonkeyPatch) -> None:
     """Bypass the SSRF host-resolution guard for tests that run offline and
-    only exercise URL rewriting / error wrapping."""
-    monkeypatch.setattr("vowl.contracts.contract._validate_public_http_url", lambda url: None)
+    only exercise URL rewriting / error wrapping. Returns a (host, ip) pair like
+    the real validator so the caller's connection-pinning still unpacks."""
+    monkeypatch.setattr(
+        "vowl.contracts.contract._validate_public_http_url",
+        lambda url: (urlparse(url).hostname or "host", "203.0.113.1"),
+    )
 
 
 def test_contract_fetches_github_blob_urls_via_raw_url(monkeypatch: pytest.MonkeyPatch):
@@ -287,11 +292,12 @@ def test_contract_http_fetch_blocks_redirect_to_internal_host(monkeypatch: pytes
     payload = yaml.safe_dump(minimal_contract_data())
     resolved: list[str] = []
 
-    def fake_validate(url: str) -> None:
+    def fake_validate(url: str):
         # Public for the first (external) hop, private for the redirect target.
         resolved.append(url)
         if "internal" in url:
             raise ContractURLError("Refusing to fetch contract from non-public address 10.0.0.9")
+        return (urlparse(url).hostname or "host", "203.0.113.1")
 
     def fake_get(url: str, timeout: int, **kwargs):
         # First call returns a redirect to an internal host.
@@ -323,6 +329,31 @@ def test_contract_http_fetch_allows_public_host(monkeypatch: pytest.MonkeyPatch)
 
     contract = Contract.load("https://example.com/contracts/users.yaml")
     assert contract.get_schema_names() == ["users"]
+
+
+def test_contract_http_fetch_pins_connection_to_validated_ip(monkeypatch: pytest.MonkeyPatch):
+    """DNS-rebinding mitigation: the outbound request must be pinned to the exact
+    IP the SSRF guard validated, so re-resolution cannot swap in an internal
+    address between validation and connection."""
+    import vowl.contracts.contract as contract_mod
+
+    payload = yaml.safe_dump(minimal_contract_data())
+    _stub_getaddrinfo(monkeypatch, "93.184.216.34")  # public IP
+
+    seen_pins: list[tuple[str, str] | None] = []
+
+    def fake_get(url: str, timeout: int, **kwargs):
+        # Capture the pin that is active while the connection would be made.
+        seen_pins.append(contract_mod._pinned_dns_target.get())
+        return FakeResponse(payload)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    Contract.load("https://example.com/contracts/users.yaml")
+
+    assert seen_pins == [("example.com", "93.184.216.34")]
+    # Pin is cleared once the fetch completes.
+    assert contract_mod._pinned_dns_target.get() is None
 
 
 def test_contract_fetches_from_s3(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_sql_security.py
+++ b/tests/test_sql_security.py
@@ -339,6 +339,50 @@ class TestDangerousFunctions:
         validate_read_only_query("SELECT read_count FROM stats", dialect="duckdb")
 
 
+class TestReplacementScanTables:
+    """Tests for the DuckDB replacement-scan guard (file path / URL as FROM target)."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            # SSRF: cloud metadata / arbitrary URL as a bare table source.
+            "SELECT * FROM 'http://169.254.169.254/latest/meta-data/'",
+            "SELECT * FROM 'https://evil.example.com/exfil'",
+            "SELECT * FROM 's3://bucket/key.parquet'",
+            # Local file disclosure via absolute / relative paths.
+            "SELECT * FROM '/data/secret.parquet'",
+            "SELECT * FROM '../../etc/passwd'",
+            "SELECT * FROM 'C:\\\\secrets\\\\creds.csv'",
+            # Bare relative data file (no separator, no scheme).
+            "SELECT * FROM 'secret.parquet'",
+            # Nested inside the COUNT(*) wrapper vowl adds around custom checks.
+            "SELECT COUNT(*) FROM (SELECT * FROM 'http://evil/x.parquet')",
+            # Hidden in a subquery / IN clause.
+            "SELECT count(*) FROM users WHERE id IN (SELECT id FROM '/etc/passwd.csv')",
+        ],
+    )
+    def test_replacement_scan_source_blocked(self, query):
+        """A file path or URL used as a table source must be rejected."""
+        with pytest.raises(SQLSecurityError) as exc_info:
+            validate_read_only_query(query, dialect="duckdb")
+        assert exc_info.value.violation_type == "replacement_scan_table"
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "SELECT * FROM my_schema.my_table",
+            "SELECT id, name FROM users WHERE active = true",
+            'SELECT * FROM "order"',  # quoted reserved word, not a path
+            'SELECT * FROM "My Table"',  # quoted identifier with a space
+            "WITH cte AS (SELECT 1 AS x) SELECT * FROM cte",
+            "SELECT a.id FROM catalog.schema.table AS a",
+        ],
+    )
+    def test_plain_identifiers_allowed(self, query):
+        """Ordinary (possibly quoted / qualified) identifiers must still pass."""
+        validate_read_only_query(query, dialect="duckdb")
+
+
 class TestSanitizeIdentifier:
     """Tests for identifier sanitization."""
 


### PR DESCRIPTION
## Summary

Follow-up hardening for the two residual findings the security scan raised against the #55 remediation. Full non-docker suite passes (728 passed, 7 skipped); `ruff format`/`check` clean.

| id | severity | finding | fix |
|----|----------|---------|-----|
| asgard-0001 | medium | Read-only SQL sandbox bypass via DuckDB **replacement scan** — a bare file path/URL used as a table source (`SELECT * FROM 'http://169.254.169.254/...'`) parses as an `exp.Table`/quoted-identifier, not an `exp.Func`, so the function-name denylist missed it | Add `_check_for_replacement_scan_tables`: reject any `FROM`/`JOIN` identifier that looks like a path or URL (`/`, `\`, `:`, or a data-file extension), wired into `validate_read_only_query` so both the Ibis and multi-source executors are covered |
| asgard-0002 | low | **DNS-rebinding TOCTOU** in `Contract._fetch_from_http_url` — validation and the actual `requests.get` resolved DNS independently | `_validate_public_http_url` returns the validated `(host, ip)`; the fetch pins the connection to that exact IP via a contextvar-scoped urllib3 `create_connection` hook (re-pinned per redirect). TLS SNI/cert stay bound to the hostname |

`asgard-0003` (multi-source replacement scan) was suppressed by the scanner's own validator as a false positive — `_ensure_tables_available` gates every table against configured adapters before `raw_sql`. The asgard-0001 fix also covers it defensively at the syntactic layer.

## Verification

- Confirmed with sqlglot that DuckDB replacement-scan syntax parses as a quoted `exp.Table` identifier (the exact bypass shape the scanner couldn't test).
- The report's exact payloads are blocked through `validate_query_security`; plain/quoted/qualified identifiers still pass.
- Confirmed the DNS pin connects to the validated IP while preserving hostname-based TLS verification.

## Tests

- `TestReplacementScanTables` in `tests/test_sql_security.py` — 9 block cases (metadata URL, s3/https, absolute/relative/Windows paths, bare data file, nested in `COUNT(*)` wrapper and subquery) + 6 allow cases (qualified, quoted reserved word, quoted-with-space, CTE, 3-part name).
- `test_contract_http_fetch_pins_connection_to_validated_ip` in `tests/test_contract_unit_coverage.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)